### PR TITLE
Member role restoration on rejoin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
+.vscode/
 requests_state.json
 requests_log.txt
 __pycache__/
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .vscode/
 requests_state.json
+role_history.json
 requests_log.txt
 __pycache__/
 CLAUDE.md

--- a/bot.py
+++ b/bot.py
@@ -389,8 +389,6 @@ class VoteView(discord.ui.View):
             feedback (str): The feedback to submit.
         """
 
-        await snapshot_member_history(interaction.user, "feedback interaction")
-
         # Submit internally
         app.submit_feedback(self.thread_id, user_id, feedback)
 

--- a/bot.py
+++ b/bot.py
@@ -90,6 +90,7 @@ async def get_requests_guild() -> Optional[discord.Guild]:
 async def snapshot_member_history(
     member: Optional[Union[discord.Member, discord.User]],
     source: str,
+    additional_roles: Optional[list[discord.Role]] = None,
 ):
     """
     Save the tracked roles currently held by a member.
@@ -97,13 +98,15 @@ async def snapshot_member_history(
     Args:
         member (Optional[Union[discord.Member, discord.User]]): The acting member if available.
         source (str): A short string describing where the snapshot came from.
+        additional_roles (Optional[list[discord.Role]]): Extra roles to include in
+            the snapshot when the cached member state is stale.
     """
 
     if not isinstance(member, discord.Member):
         return
 
     try:
-        role_history.snapshot_member_roles(member)
+        role_history.snapshot_member_roles(member, additional_roles=additional_roles)
         logger.info(
             f"Saved role snapshot for {member.display_name} ({member.id}) from {source}"
         )
@@ -634,7 +637,11 @@ async def end_vote(view: VoteView):
             return
         else:
             await member.add_roles(role)
-            await snapshot_member_history(member, "approved role grant")
+            await snapshot_member_history(
+                member,
+                "approved role grant",
+                additional_roles=[role],
+            )
             await thread.send(
                 f"Congratulations, {view.thread_owner.mention}! Your application for {request.role} has been approved."
             )

--- a/bot.py
+++ b/bot.py
@@ -63,6 +63,7 @@ def setup_logger():
 
 
 logger = setup_logger()
+requests_guild_id: Optional[int] = None
 
 
 ####################################
@@ -87,6 +88,45 @@ async def get_requests_guild() -> Optional[discord.Guild]:
     return getattr(channel, "guild", None)
 
 
+async def get_requests_guild_id() -> Optional[int]:
+    """
+    Get and cache the guild ID for the configured request forum.
+
+    Returns:
+        Optional[int]: The configured request guild ID if available.
+    """
+
+    global requests_guild_id
+
+    if requests_guild_id is not None:
+        return requests_guild_id
+
+    requests_guild = await get_requests_guild()
+    if requests_guild is None:
+        return None
+
+    requests_guild_id = requests_guild.id
+    return requests_guild_id
+
+
+async def is_requests_guild_member(member: discord.Member) -> bool:
+    """
+    Check whether a member belongs to the configured request guild.
+
+    Args:
+        member (discord.Member): The member to validate.
+
+    Returns:
+        bool: True when the member belongs to the request guild.
+    """
+
+    cached_requests_guild_id = await get_requests_guild_id()
+    if cached_requests_guild_id is None:
+        return False
+
+    return member.guild.id == cached_requests_guild_id
+
+
 async def snapshot_member_history(
     member: Optional[Union[discord.Member, discord.User]],
     source: str,
@@ -105,14 +145,22 @@ async def snapshot_member_history(
     if not isinstance(member, discord.Member):
         return
 
+    resolved_member: discord.Member = member
+
+    if not await is_requests_guild_member(resolved_member):
+        return
+
     try:
-        role_history.snapshot_member_roles(member, additional_roles=additional_roles)
+        role_history.snapshot_member_roles(
+            resolved_member,
+            additional_roles=additional_roles,
+        )
         logger.info(
-            f"Saved role snapshot for {member.display_name} ({member.id}) from {source}"
+            f"Saved role snapshot for {resolved_member.display_name} ({resolved_member.id}) from {source}"
         )
     except Exception as error:
         logger.error(
-            f"Failed to save role snapshot for member {member.id} from {source}: {error}"
+            f"Failed to save role snapshot for member {resolved_member.id} from {source}: {error}"
         )
 
 
@@ -185,10 +233,13 @@ async def restore_member_roles(member: discord.Member):
         member (discord.Member): The member who rejoined the guild.
     """
 
+    if not await is_requests_guild_member(member):
+        return
+
     highest_rank_role, additional_roles, skip_messages = role_history.get_restore_roles(member)
 
     if highest_rank_role is None and not additional_roles:
-        if role_history.get_user_history(member.id) is not None:
+        if role_history.get_user_history(member.guild.id, member.id) is not None:
             logger.info(
                 f"No restorable roles were found for returning member {member.display_name} ({member.id})"
             )
@@ -683,7 +734,13 @@ async def on_ready():
                      thread_title, end_time), message_id=request.bot_message_id)
 
     logger.info("Loaded all active role requests!")
-    logger.info(f"Loaded {len(role_history.user_role_history)} member role snapshots")
+    await get_requests_guild_id()
+    logger.info(f"Loaded {role_history.get_snapshot_count()} member role snapshots")
+
+    if role_history.get_legacy_snapshot_count():
+        logger.warning(
+            "Ignored legacy role snapshots without guild IDs until fresh guild-scoped snapshots are captured"
+        )
 
 
 @bot.event
@@ -695,6 +752,8 @@ async def on_member_join(member: discord.Member):
         member (discord.Member): The member who joined.
     """
 
+    # Ignore joins from unrelated guilds because role history is only tracked
+    # for the server that owns the configured role request forum
     await restore_member_roles(member)
 
 

--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ from utils import get_user_votes, send_long_message
 from discord.ext import tasks
 from discord import Embed, Colour
 from datetime import datetime, timezone
+from typing import Optional, Union
 from config import (
     CHECK_TIME,
     PROMPT_AFTER_FIRST_FEEDBACK,
@@ -24,12 +25,18 @@ from config import (
 )
 from app import RequestsManager
 from request import RoleRequest
+from role_history import RoleHistoryManager
 
 # SETUP AND INITIALIZATION
 
-bot = discord.Bot()
+intents = discord.Intents.default()
+intents.members = True
+
+bot = discord.Bot(intents=intents)
 app = RequestsManager()
 app.load_state()
+role_history = RoleHistoryManager()
+role_history.load_state()
 
 # Configure logging
 
@@ -59,6 +66,176 @@ logger = setup_logger()
 
 
 ####################################
+
+
+async def get_requests_guild() -> Optional[discord.Guild]:
+    """
+    Get the guild that owns the configured role request forum channel.
+
+    Returns:
+        Optional[discord.Guild]: The resolved guild if available.
+    """
+
+    channel = bot.get_channel(CHANNEL_ID)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(CHANNEL_ID)
+        except Exception as error:
+            logger.error(f"Failed to fetch configured forum channel {CHANNEL_ID}: {error}")
+            return None
+
+    return getattr(channel, "guild", None)
+
+
+async def snapshot_member_history(
+    member: Optional[Union[discord.Member, discord.User]],
+    source: str,
+):
+    """
+    Save the tracked roles currently held by a member.
+
+    Args:
+        member (Optional[Union[discord.Member, discord.User]]): The acting member if available.
+        source (str): A short string describing where the snapshot came from.
+    """
+
+    if not isinstance(member, discord.Member):
+        return
+
+    try:
+        role_history.snapshot_member_roles(member)
+        logger.info(
+            f"Saved role snapshot for {member.display_name} ({member.id}) from {source}"
+        )
+    except Exception as error:
+        logger.error(
+            f"Failed to save role snapshot for member {member.id} from {source}: {error}"
+        )
+
+
+async def get_assignable_roles(
+    member: discord.Member,
+    roles_to_restore: list[discord.Role],
+) -> tuple[list[discord.Role], list[str]]:
+    """
+    Filter a role list down to roles the bot can safely assign.
+
+    Args:
+        member (discord.Member): The member who may receive roles.
+        roles_to_restore (list[discord.Role]): The candidate roles to restore.
+
+    Returns:
+        tuple[list[discord.Role], list[str]]: Assignable roles and skip reasons.
+    """
+
+    skip_messages: list[str] = []
+
+    if member.id == member.guild.owner_id:
+        skip_messages.append("Cannot restore roles for the server owner")
+        return [], skip_messages
+
+    bot_member = member.guild.me
+    if bot_member is None and bot.user is not None:
+        try:
+            bot_member = await member.guild.fetch_member(bot.user.id)
+        except Exception as error:
+            skip_messages.append(f"Could not resolve the bot member: {error}")
+            return [], skip_messages
+
+    if bot_member is None:
+        skip_messages.append("Could not resolve the bot member")
+        return [], skip_messages
+
+    if not bot_member.guild_permissions.manage_roles:
+        skip_messages.append("Bot is missing the Manage Roles permission")
+        return [], skip_messages
+
+    assignable_roles: list[discord.Role] = []
+    existing_role_ids = {role.id for role in member.roles}
+
+    # Check each role independently so one bad role does not block the rest
+    for role in roles_to_restore:
+        if role.id in existing_role_ids:
+            skip_messages.append(f"Member already has '{role.name}'")
+            continue
+
+        if role.managed:
+            skip_messages.append(f"Role '{role.name}' is managed and cannot be assigned")
+            continue
+
+        if role.position >= bot_member.top_role.position:
+            skip_messages.append(
+                f"Role '{role.name}' is above or equal to the bot's top role"
+            )
+            continue
+
+        assignable_roles.append(role)
+
+    return assignable_roles, skip_messages
+
+
+async def restore_member_roles(member: discord.Member):
+    """
+    Restore tracked roles for a member who has rejoined.
+
+    Args:
+        member (discord.Member): The member who rejoined the guild.
+    """
+
+    highest_rank_role, additional_roles, skip_messages = role_history.get_restore_roles(member)
+
+    if highest_rank_role is None and not additional_roles:
+        if role_history.get_user_history(member.id) is not None:
+            logger.info(
+                f"No restorable roles were found for returning member {member.display_name} ({member.id})"
+            )
+        return
+
+    roles_to_restore: list[discord.Role] = []
+    if highest_rank_role is not None:
+        roles_to_restore.append(highest_rank_role)
+
+    # Avoid restoring the same role twice if a category changed in config
+    seen_role_ids = {role.id for role in roles_to_restore}
+    for role in additional_roles:
+        if role.id not in seen_role_ids:
+            roles_to_restore.append(role)
+            seen_role_ids.add(role.id)
+
+    assignable_roles, assignable_skip_messages = await get_assignable_roles(
+        member,
+        roles_to_restore,
+    )
+    skip_messages.extend(assignable_skip_messages)
+
+    if not assignable_roles:
+        logger.info(
+            f"No roles restored for returning member {member.display_name} ({member.id})"
+        )
+        for skip_message in skip_messages:
+            logger.info(f"Restore skip for {member.id}: {skip_message}")
+        return
+
+    try:
+        await member.add_roles(
+            *assignable_roles,
+            reason="Restoring tracked roles after member rejoined",
+        )
+        restored_role_names = ", ".join(role.name for role in assignable_roles)
+        logger.info(
+            f"Restored roles to {member.display_name} ({member.id}): {restored_role_names}"
+        )
+    except discord.Forbidden:
+        logger.error(
+            f"Failed to restore roles for {member.display_name} ({member.id}) due to missing permissions"
+        )
+    except discord.HTTPException as error:
+        logger.error(
+            f"Failed to restore roles for {member.display_name} ({member.id}): {error}"
+        )
+
+    for skip_message in skip_messages:
+        logger.info(f"Restore skip for {member.id}: {skip_message}")
 
 class VoteView(discord.ui.View):
     def __init__(
@@ -111,6 +288,7 @@ class VoteView(discord.ui.View):
         """
 
         user: discord.Member = interaction.user
+        await snapshot_member_history(user, "vote interaction")
 
         # People can't vote on their own requests
         if user.id == self.thread_owner.id and not DEV_MODE:
@@ -174,6 +352,7 @@ class VoteView(discord.ui.View):
 
         thread_id = self.thread_id
         user_id = interaction.user.id
+        await snapshot_member_history(interaction.user, "cancel vote interaction")
 
         try:
             # Get the request
@@ -206,6 +385,8 @@ class VoteView(discord.ui.View):
             user_id (int): The ID of the user submitting the feedback.
             feedback (str): The feedback to submit.
         """
+
+        await snapshot_member_history(interaction.user, "feedback interaction")
 
         # Submit internally
         app.submit_feedback(self.thread_id, user_id, feedback)
@@ -414,7 +595,13 @@ async def end_vote(view: VoteView):
             return
 
         # Get guild and role from the discord api
-        guild = (bot.get_channel(CHANNEL_ID) or await bot.fetch_guild(CHANNEL_ID)).guild
+        guild = await get_requests_guild()
+        if guild is None:
+            logger.error("Error: Could not resolve the requests guild.")
+            await thread.send("Error: Could not resolve the server.")
+            await _finish_vote(thread, request)
+            return
+
         role = discord.utils.get(guild.roles, name=request.role)
 
         if not role:
@@ -424,9 +611,11 @@ async def end_vote(view: VoteView):
             await _finish_vote(thread, request)
             return
 
-        # Get the member from the user (yes it's confusing)
-        # NOTE: This will crash if they left the server, which isn't that much of an issue I suppose
-        member = guild.get_member(view.thread_owner.id) or await guild.fetch_member(view.thread_owner.id)
+        # Get the member from the user and handle users who already left
+        try:
+            member = guild.get_member(view.thread_owner.id) or await guild.fetch_member(view.thread_owner.id)
+        except discord.NotFound:
+            member = None
 
         if not member:
             logger.error(
@@ -445,6 +634,7 @@ async def end_vote(view: VoteView):
             return
         else:
             await member.add_roles(role)
+            await snapshot_member_history(member, "approved role grant")
             await thread.send(
                 f"Congratulations, {view.thread_owner.mention}! Your application for {request.role} has been approved."
             )
@@ -488,6 +678,19 @@ async def on_ready():
                      thread_title, end_time), message_id=request.bot_message_id)
 
     logger.info("Loaded all active role requests!")
+    logger.info(f"Loaded {len(role_history.user_role_history)} member role snapshots")
+
+
+@bot.event
+async def on_member_join(member: discord.Member):
+    """
+    Event handler for when a member joins the guild.
+
+    Args:
+        member (discord.Member): The member who joined.
+    """
+
+    await restore_member_roles(member)
 
 
 async def _init_request(thread: discord.Thread):
@@ -522,9 +725,23 @@ async def _init_request(thread: discord.Thread):
 
     # Bunch of work needed to check roles below
     request = app.get_request(thread_id)
-    guild = (bot.get_channel(CHANNEL_ID) or await bot.fetch_guild(CHANNEL_ID)).guild
+    guild = await get_requests_guild()
+    if guild is None:
+        logger.error("Error: Could not resolve the requests guild.")
+        app.remove_request(thread_id)
+        await thread.send("Error: Could not resolve the server for this request.")
+        return
+
     owner = await bot.get_or_fetch_user(thread.owner_id)
-    owner_m = guild.get_member(thread.owner_id) or await guild.fetch_member(thread.owner_id)
+    try:
+        owner_m = guild.get_member(thread.owner_id) or await guild.fetch_member(thread.owner_id)
+    except discord.NotFound:
+        logger.error(f"Error: Thread owner {thread.owner_id} is not in the server.")
+        app.remove_request(thread_id)
+        await thread.send("Error: Could not find the request owner in the server.")
+        return
+
+    await snapshot_member_history(owner_m, "request creation")
 
     # People can't apply for a role they already have
     if request.role in [role.name for role in owner_m.roles] and not DEV_MODE:

--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,7 @@ from config import (
     VALID_ROLES,
     LOG_FILE_NAME,
     CLOSE_POST,
+    TRACKED_ROLE_NAMES,
 )
 from app import RequestsManager
 from request import RoleRequest
@@ -290,6 +291,22 @@ async def restore_member_roles(member: discord.Member):
 
     for skip_message in skip_messages:
         logger.info(f"Restore skip for {member.id}: {skip_message}")
+
+
+def _get_tracked_role_ids(member: discord.Member) -> set[int]:
+    """
+    Get the tracked role IDs currently held by a member.
+
+    Args:
+        member (discord.Member): The member to inspect.
+
+    Returns:
+        set[int]: The tracked role IDs held by the member.
+    """
+
+    return {
+        role.id for role in member.roles if role.name in TRACKED_ROLE_NAMES
+    }
 
 class VoteView(discord.ui.View):
     def __init__(
@@ -755,6 +772,25 @@ async def on_member_join(member: discord.Member):
     # Ignore joins from unrelated guilds because role history is only tracked
     # for the server that owns the configured role request forum
     await restore_member_roles(member)
+
+
+@bot.event
+async def on_member_update(before: discord.Member, after: discord.Member):
+    """
+    Event handler for when a member is updated.
+
+    Args:
+        before (discord.Member): The member state before the update.
+        after (discord.Member): The member state after the update.
+    """
+
+    if not await is_requests_guild_member(after):
+        return
+
+    if _get_tracked_role_ids(before) == _get_tracked_role_ids(after):
+        return
+
+    await snapshot_member_history(after, "member role update")
 
 
 async def _init_request(thread: discord.Thread):

--- a/cogs/open_cmds.py
+++ b/cogs/open_cmds.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from bot import logger, app
+from bot import logger, app, snapshot_member_history
 from config import ACCEPTANCE_THRESHOLDS, CHANNEL_ID, IGNORE_VOTE_WEIGHT, ROLE_VOTES, VALID_ROLES
 
 # Bunch of setup for the help command
@@ -73,10 +73,12 @@ class OpenCmds(commands.Cog):
         """
         Provide help instructions and a link to the source code.
         """
+        await snapshot_member_history(ctx.user, "help command")
         await ctx.respond(help_text)
 
     @commands.slash_command(description="Returns the latency of the bot in ms")
     async def ping(self, ctx):
+        await snapshot_member_history(ctx.user, "ping command")
         latency = self.bot.latency
         latency_ms = latency * 1000
         await ctx.respond(f"`Ping: {latency_ms:.2f}ms`")
@@ -92,6 +94,8 @@ class OpenCmds(commands.Cog):
             ctx (discord.ApplicationContext): The context of the command invocation.
             vote (str): The vote to cast, either "Yes" or "No".
         """
+        await snapshot_member_history(ctx.user, "vote command")
+
         # Check if the command is used in a thread
         if not isinstance(ctx.channel, discord.Thread) or ctx.channel.parent_id != CHANNEL_ID:
             await ctx.respond("This command can only be used in a role request thread.", ephemeral=True)
@@ -122,6 +126,8 @@ class OpenCmds(commands.Cog):
         Args:
             ctx (discord.ApplicationContext): The context of the command invocation.
         """
+        await snapshot_member_history(ctx.user, "cancel vote command")
+
         # Check if the command is used in a thread
         if not isinstance(ctx.channel, discord.Thread) or ctx.channel.parent_id != CHANNEL_ID:
             await ctx.respond("This command can only be used in a role request thread.", ephemeral=True)
@@ -153,6 +159,8 @@ class OpenCmds(commands.Cog):
             ctx (discord.ApplicationContext): The context of the command invocation.
             feedback (str): The feedback to submit.
         """
+        await snapshot_member_history(ctx.user, "submit feedback command")
+
         # Check if the command is used in a thread
         if not isinstance(ctx.channel, discord.Thread) or ctx.channel.parent_id != CHANNEL_ID:
             await ctx.respond("This command can only be used in a role request thread.", ephemeral=True)

--- a/cogs/restricted_cmds.py
+++ b/cogs/restricted_cmds.py
@@ -4,7 +4,7 @@ import discord
 from utils import get_user_names, respond_long_message, send_long_message
 from typing import Optional
 from discord.ext import commands
-from bot import logger, app, end_vote, _init_request
+from bot import logger, app, end_vote, _init_request, snapshot_member_history
 from config import CHANNEL_ID, COMMAND_WHITELISTED_ROLES, DEV_MODE, LOG_FILE_NAME, MOD_LOG_CHANNEL_ID
 
 
@@ -85,6 +85,8 @@ class RestrictedCmds(commands.Cog):
             ctx (discord.ext.commands.Context): The context of the command.
         """
 
+        await snapshot_member_history(ctx.user, "create vote command")
+
         # Get the thread
         thread = await self._restricted_cmd_ctx_to_thread(ctx)
         if thread is None:
@@ -112,6 +114,8 @@ class RestrictedCmds(commands.Cog):
             ctx (discord.ApplicationContext): The context of the command.
             outcome (str): The outcome of the vote ("Approve", "Deny" or "Abstain").
         """
+
+        await snapshot_member_history(ctx.user, "end vote early command")
 
         # Get the thread
         thread = await self._restricted_cmd_ctx_to_thread(ctx)
@@ -160,6 +164,8 @@ class RestrictedCmds(commands.Cog):
         """
 
         try:
+            await snapshot_member_history(ctx.user, "force delete request command")
+
             # Get the thread
             thread = await self._restricted_cmd_ctx_to_thread(ctx)
             if thread is None:
@@ -224,6 +230,8 @@ class RestrictedCmds(commands.Cog):
         """
 
         try:
+            await snapshot_member_history(ctx.user, "show votes command")
+
             # Get the thread
             thread = await self._restricted_cmd_ctx_to_thread(ctx)
             if thread is None:
@@ -318,6 +326,8 @@ class RestrictedCmds(commands.Cog):
         Args:
             ctx (discord.ext.commands.Context): The context of the command.
         """
+
+        await snapshot_member_history(ctx.user, "send log command")
 
         # Get the log file
         log_file = open(LOG_FILE_NAME, "rb")

--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ class Role:
     can_be_voted_on: bool = True # If true, this role can be voted on
     ignore_vote_weight: bool = False # If true, requests for this role will ignore the vote weight of other roles voting on it
     command_whitelisted: bool = False  # If true, this role can use restricted commands
+    category: str = "rank"  # Controls restore behavior: "rank", "additional", or "other"
 
 
 ROLES = [
@@ -21,6 +22,7 @@ ROLES = [
         can_be_voted_on=False,
         ignore_vote_weight=False,
         command_whitelisted=False,
+        category="rank",
     ),
     Role(
         name="Adept",
@@ -43,11 +45,13 @@ ROLES = [
         votes=DEFAULT_VOTE,
         percent_accept=0.66,
         ignore_vote_weight=True,
+        category="additional",
     ),
     Role(
         name="Visionary",
         votes=DEFAULT_VOTE,
         percent_accept=0.75,
+        category="additional",
     ),
     Role(
         name="Custodian (admin)",
@@ -55,6 +59,7 @@ ROLES = [
         percent_accept=0.0,
         can_be_voted_on=False,
         command_whitelisted=True,
+        category="other",
     ),
     Role(
         name="Sentinel (mod)",
@@ -62,6 +67,7 @@ ROLES = [
         percent_accept=0.0,
         can_be_voted_on=False,
         command_whitelisted=True,
+        category="other",
     ),
     Role(
         name="Bot Manager",
@@ -69,6 +75,7 @@ ROLES = [
         percent_accept=0.0,
         can_be_voted_on=False,
         command_whitelisted=True,
+        category="other",
     ),
 ]
 
@@ -78,6 +85,33 @@ ROLE_VOTES = {role.name: role.votes for role in ROLES}
 
 # Roles that can use restricted commands
 COMMAND_WHITELISTED_ROLES = [role.name for role in ROLES if role.command_whitelisted]
+
+# Role category lookup for restore logic
+ROLE_CATEGORIES = {role.name: role.category for role in ROLES}
+
+# Roles that should be tracked in the restore store
+TRACKED_ROLE_NAMES = [
+    role.name for role in ROLES if role.category in {"rank", "additional"}
+]
+
+# Role names grouped by restore category
+RANK_ROLE_NAMES = [role.name for role in ROLES if role.category == "rank"]
+ADDITIONAL_ROLE_NAMES = [
+    role.name for role in ROLES if role.category == "additional"
+]
+
+# Fallback ordering used if live Discord role positions are unavailable
+RANK_ROLE_ORDER = [
+    "Excelsior",
+    "Paragon",
+    "Expert",
+    "Adept",
+]
+
+# Precomputed lookup for fallback rank ordering
+RANK_ROLE_ORDER_INDEX = {
+    role_name: index for index, role_name in enumerate(RANK_ROLE_ORDER)
+}
 
 # Roles to be voted on
 VALID_ROLES = [role.name for role in ROLES if role.can_be_voted_on]
@@ -104,5 +138,6 @@ PROMPT_AFTER_FIRST_FEEDBACK = True # whether to only prompt people until someone
 CHANNEL_ID = 1101149194498089051  # Forum channel ID
 MOD_LOG_CHANNEL_ID = 546319957827518474  # Channel for moderation logs
 STATE_FILE_NAME = "requests_state.json"
+ROLE_HISTORY_FILE_NAME = "role_history.json"
 LOG_FILE_NAME = "requests_log.txt"
 DEV_MODE = False  # for ease of testing, turns off many checks

--- a/config.py
+++ b/config.py
@@ -94,12 +94,6 @@ TRACKED_ROLE_NAMES = [
     role.name for role in ROLES if role.category in {"rank", "additional"}
 ]
 
-# Role names grouped by restore category
-RANK_ROLE_NAMES = [role.name for role in ROLES if role.category == "rank"]
-ADDITIONAL_ROLE_NAMES = [
-    role.name for role in ROLES if role.category == "additional"
-]
-
 # Fallback ordering used if live Discord role positions are unavailable
 RANK_ROLE_ORDER = [
     "Excelsior",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+py-cord>=2.6.1
+python-dotenv>=1.0.0
+matplotlib>=3.7.0
+asyncio>=3.4.3
+typing>=3.7.4.3 

--- a/role_history.py
+++ b/role_history.py
@@ -1,0 +1,307 @@
+import json
+import os
+from datetime import datetime, timezone
+from typing import Optional
+
+import discord
+
+from config import ROLE_CATEGORIES, ROLE_HISTORY_FILE_NAME, RANK_ROLE_ORDER_INDEX, TRACKED_ROLE_NAMES
+
+
+class RoleHistoryManager:
+    def __init__(self, file_name: str = ROLE_HISTORY_FILE_NAME):
+        """
+        Initialize the role history manager.
+
+        Args:
+            file_name (str): The JSON file used for persistence.
+        """
+
+        self.file_name = file_name
+        self.user_role_history: dict[int, dict] = {}
+
+    def _timestamp(self) -> str:
+        """
+        Get the current UTC timestamp in ISO format.
+
+        Returns:
+            str: The current UTC timestamp.
+        """
+
+        return datetime.now(timezone.utc).isoformat()
+
+    def _build_empty_user_record(self, user_id: int) -> dict:
+        """
+        Build a new empty record for a user.
+
+        Args:
+            user_id (int): The Discord user ID.
+
+        Returns:
+            dict: An initialized user record.
+        """
+
+        return {
+            "user_id": user_id,
+            "roles": {},
+            "updated_at": self._timestamp(),
+        }
+
+    def _normalize_role_record(self, role_record: dict) -> dict:
+        """
+        Normalize a stored role record for forward compatibility.
+
+        Args:
+            role_record (dict): The stored role record.
+
+        Returns:
+            dict: The normalized role record.
+        """
+
+        role_name = role_record.get("role_name", "")
+        category = role_record.get("category", ROLE_CATEGORIES.get(role_name, "other"))
+        raw_role_id = role_record.get("role_id", 0)
+
+        # Keep legacy or partially populated records loadable instead of failing
+        try:
+            normalized_role_id = int(raw_role_id or 0)
+        except (TypeError, ValueError):
+            normalized_role_id = 0
+
+        return {
+            "role_id": normalized_role_id,
+            "role_name": role_name,
+            "category": category,
+            "last_seen_at": role_record.get("last_seen_at", self._timestamp()),
+        }
+
+    def save_state(self):
+        """
+        Save the current role history to disk.
+        """
+
+        with open(self.file_name, "w", encoding="utf-8") as file:
+            json.dump(
+                {
+                    "users": {
+                        user_id: user_record
+                        for user_id, user_record in self.user_role_history.items()
+                    }
+                },
+                file,
+                indent=4,
+            )
+
+    def load_state(self):
+        """
+        Load the current role history from disk.
+        """
+
+        if not os.path.exists(self.file_name):
+            self.user_role_history = {}
+            return
+
+        with open(self.file_name, "r", encoding="utf-8") as file:
+            file_content = file.read().strip()
+
+        if not file_content:
+            self.user_role_history = {}
+            return
+
+        data = json.loads(file_content)
+        raw_users = data.get("users", data) if isinstance(data, dict) else {}
+
+        normalized_users = {}
+        for user_id, user_record in raw_users.items():
+            if not isinstance(user_record, dict):
+                continue
+
+            normalized_roles = {}
+            for role_id, role_record in (user_record.get("roles") or {}).items():
+                if not isinstance(role_record, dict):
+                    continue
+
+                normalized_role = self._normalize_role_record(role_record)
+                normalized_roles[str(normalized_role["role_id"] or role_id)] = normalized_role
+
+            normalized_users[int(user_id)] = {
+                "user_id": int(user_record.get("user_id", user_id)),
+                "roles": normalized_roles,
+                "updated_at": user_record.get("updated_at", self._timestamp()),
+            }
+
+        self.user_role_history = normalized_users
+
+    def get_user_history(self, user_id: int) -> Optional[dict]:
+        """
+        Get stored role history for a user.
+
+        Args:
+            user_id (int): The Discord user ID.
+
+        Returns:
+            Optional[dict]: The stored user record if one exists.
+        """
+
+        return self.user_role_history.get(user_id)
+
+    def snapshot_member_roles(self, member: discord.Member) -> dict:
+        """
+        Save the member's currently tracked roles as the latest known snapshot.
+
+        Args:
+            member (discord.Member): The member whose roles should be recorded.
+
+        Returns:
+            dict: The updated user record.
+        """
+
+        user_record = self.user_role_history.get(member.id) or self._build_empty_user_record(member.id)
+        snapshot_time = self._timestamp()
+        tracked_roles = {}
+
+        # Store the latest observed tracked-role set so restores match the
+        # member's most recently known state instead of every role ever seen
+        for role in member.roles:
+            if role.name not in TRACKED_ROLE_NAMES:
+                continue
+
+            tracked_roles[str(role.id)] = {
+                "role_id": role.id,
+                "role_name": role.name,
+                "category": ROLE_CATEGORIES.get(role.name, "other"),
+                "last_seen_at": snapshot_time,
+            }
+
+        user_record["roles"] = tracked_roles
+        user_record["updated_at"] = snapshot_time
+        self.user_role_history[member.id] = user_record
+        self.save_state()
+
+        return user_record
+
+    def _resolve_stored_role(self, guild: discord.Guild, role_record: dict) -> Optional[discord.Role]:
+        """
+        Resolve a stored role record back to a live Discord role.
+
+        Args:
+            guild (discord.Guild): The guild to search in.
+            role_record (dict): The stored role record.
+
+        Returns:
+            Optional[discord.Role]: The resolved Discord role if it still exists.
+        """
+
+        role_id = role_record.get("role_id")
+        role_name = role_record.get("role_name")
+
+        if role_id:
+            resolved_role = guild.get_role(int(role_id))
+            if resolved_role is not None:
+                return resolved_role
+
+        if role_name:
+            return discord.utils.get(guild.roles, name=role_name)
+
+        return None
+
+    def _get_effective_category(self, role_record: dict, resolved_role: Optional[discord.Role]) -> str:
+        """
+        Get the category that should be used for restore decisions.
+
+        Args:
+            role_record (dict): The stored role record.
+            resolved_role (Optional[discord.Role]): The resolved Discord role if it exists.
+
+        Returns:
+            str: The role category used for restore logic.
+        """
+
+        if resolved_role is not None:
+            return ROLE_CATEGORIES.get(
+                resolved_role.name,
+                role_record.get("category") or "other",
+            )
+
+        return (
+            role_record.get("category")
+            or ROLE_CATEGORIES.get(role_record.get("role_name", ""), "other")
+        )
+
+    def _get_rank_sort_key(self, role_record: dict, resolved_role: Optional[discord.Role]) -> tuple[int, int, int]:
+        """
+        Build a sort key for choosing the highest rank role.
+
+        Args:
+            role_record (dict): The stored role record.
+            resolved_role (Optional[discord.Role]): The resolved Discord role if it exists.
+
+        Returns:
+            tuple[int, int, int]: A key where larger values mean higher priority.
+        """
+
+        role_name = role_record.get("role_name", "")
+        fallback_rank_index = RANK_ROLE_ORDER_INDEX.get(role_name, len(RANK_ROLE_ORDER_INDEX))
+        fallback_score = -fallback_rank_index
+
+        if resolved_role is not None:
+            return (1, resolved_role.position, fallback_score)
+
+        return (0, 0, fallback_score)
+
+    def get_restore_roles(self, member: discord.Member) -> tuple[Optional[discord.Role], list[discord.Role], list[str]]:
+        """
+        Resolve the stored roles that should be restored for a member.
+
+        Args:
+            member (discord.Member): The returning guild member.
+
+        Returns:
+            tuple[Optional[discord.Role], list[discord.Role], list[str]]:
+                The highest rank role, additional roles, and skipped-role messages.
+        """
+
+        user_record = self.get_user_history(member.id)
+        if user_record is None:
+            return None, [], []
+
+        rank_candidates: list[tuple[dict, Optional[discord.Role]]] = []
+        additional_roles: dict[int, discord.Role] = {}
+        skipped_roles: list[str] = []
+
+        for role_record in user_record.get("roles", {}).values():
+            resolved_role = self._resolve_stored_role(member.guild, role_record)
+            effective_category = self._get_effective_category(role_record, resolved_role)
+            role_name = role_record.get("role_name", f"#{role_record.get('role_id', 'unknown')}")
+
+            if effective_category not in {"rank", "additional"}:
+                continue
+
+            if resolved_role is None:
+                skipped_roles.append(f"Stored role '{role_name}' no longer exists")
+                continue
+
+            if resolved_role.name not in TRACKED_ROLE_NAMES:
+                skipped_roles.append(f"Role '{resolved_role.name}' is no longer configured for restore")
+                continue
+
+            if effective_category == "rank":
+                rank_candidates.append((role_record, resolved_role))
+                continue
+
+            additional_roles[resolved_role.id] = resolved_role
+
+        highest_rank_role = None
+        if rank_candidates:
+            highest_rank_role = max(
+                rank_candidates,
+                key=lambda candidate: self._get_rank_sort_key(candidate[0], candidate[1]),
+            )[1]
+
+        additional_role_list = sorted(
+            additional_roles.values(),
+            key=lambda role: role.position,
+            reverse=True,
+        )
+
+        return highest_rank_role, additional_role_list, skipped_roles

--- a/role_history.py
+++ b/role_history.py
@@ -145,12 +145,18 @@ class RoleHistoryManager:
 
         return self.user_role_history.get(user_id)
 
-    def snapshot_member_roles(self, member: discord.Member) -> dict:
+    def snapshot_member_roles(
+        self,
+        member: discord.Member,
+        additional_roles: Optional[list[discord.Role]] = None,
+    ) -> dict:
         """
         Save the member's currently tracked roles as the latest known snapshot.
 
         Args:
             member (discord.Member): The member whose roles should be recorded.
+            additional_roles (Optional[list[discord.Role]]): Extra roles to force
+                into the snapshot when the cached member roles are not yet updated.
 
         Returns:
             dict: The updated user record.
@@ -162,7 +168,14 @@ class RoleHistoryManager:
 
         # Store the latest observed tracked-role set so restores match the
         # member's most recently known state instead of every role ever seen
-        for role in member.roles:
+        roles_to_snapshot = {role.id: role for role in member.roles}
+
+        # Include explicitly supplied roles so post-grant snapshots do not depend
+        # on the gateway cache updating before persistence runs
+        for additional_role in additional_roles or []:
+            roles_to_snapshot[additional_role.id] = additional_role
+
+        for role in roles_to_snapshot.values():
             if role.name not in TRACKED_ROLE_NAMES:
                 continue
 

--- a/role_history.py
+++ b/role_history.py
@@ -18,7 +18,8 @@ class RoleHistoryManager:
         """
 
         self.file_name = file_name
-        self.user_role_history: dict[int, dict] = {}
+        self.user_role_history: dict[int, dict[int, dict]] = {}
+        self.legacy_user_role_history: dict[int, dict] = {}
 
     def _timestamp(self) -> str:
         """
@@ -30,11 +31,12 @@ class RoleHistoryManager:
 
         return datetime.now(timezone.utc).isoformat()
 
-    def _build_empty_user_record(self, user_id: int) -> dict:
+    def _build_empty_user_record(self, guild_id: int, user_id: int) -> dict:
         """
         Build a new empty record for a user.
 
         Args:
+            guild_id (int): The Discord guild ID.
             user_id (int): The Discord user ID.
 
         Returns:
@@ -42,6 +44,7 @@ class RoleHistoryManager:
         """
 
         return {
+            "guild_id": guild_id,
             "user_id": user_id,
             "roles": {},
             "updated_at": self._timestamp(),
@@ -75,6 +78,108 @@ class RoleHistoryManager:
             "last_seen_at": role_record.get("last_seen_at", self._timestamp()),
         }
 
+    def _normalize_user_record(self, guild_id: int, user_id: int, user_record: dict) -> dict:
+        """
+        Normalize a stored user record for a specific guild.
+
+        Args:
+            guild_id (int): The Discord guild ID that owns the snapshot.
+            user_id (int): The Discord user ID.
+            user_record (dict): The stored user record.
+
+        Returns:
+            dict: The normalized user record.
+        """
+
+        normalized_roles = {}
+        for role_id, role_record in (user_record.get("roles") or {}).items():
+            if not isinstance(role_record, dict):
+                continue
+
+            normalized_role = self._normalize_role_record(role_record)
+            normalized_roles[str(normalized_role["role_id"] or role_id)] = normalized_role
+
+        return {
+            "guild_id": int(user_record.get("guild_id", guild_id)),
+            "user_id": int(user_record.get("user_id", user_id)),
+            "roles": normalized_roles,
+            "updated_at": user_record.get("updated_at", self._timestamp()),
+        }
+
+    def _normalize_guild_users(self, guild_id: int, raw_users: dict) -> dict[int, dict]:
+        """
+        Normalize all user records that belong to one guild.
+
+        Args:
+            guild_id (int): The Discord guild ID.
+            raw_users (dict): The raw serialized users mapping.
+
+        Returns:
+            dict[int, dict]: The normalized user records for the guild.
+        """
+
+        normalized_users: dict[int, dict] = {}
+        for user_id, user_record in raw_users.items():
+            if not isinstance(user_record, dict):
+                continue
+
+            normalized_user_id = int(user_record.get("user_id", user_id))
+            normalized_users[normalized_user_id] = self._normalize_user_record(
+                guild_id,
+                normalized_user_id,
+                user_record,
+            )
+
+        return normalized_users
+
+    def _normalize_legacy_users(self, raw_users: dict) -> dict[int, dict]:
+        """
+        Normalize legacy snapshots that were saved without guild IDs.
+
+        Args:
+            raw_users (dict): The raw serialized legacy users mapping.
+
+        Returns:
+            dict[int, dict]: The normalized legacy user records.
+        """
+
+        normalized_users: dict[int, dict] = {}
+        for user_id, user_record in raw_users.items():
+            if not isinstance(user_record, dict):
+                continue
+
+            normalized_user_id = int(user_record.get("user_id", user_id))
+
+            # Store unknown-guild snapshots separately so restore logic never
+            # trusts data that could have been overwritten by another server
+            normalized_users[normalized_user_id] = self._normalize_user_record(
+                0,
+                normalized_user_id,
+                user_record,
+            )
+
+        return normalized_users
+
+    def get_snapshot_count(self) -> int:
+        """
+        Count all guild-scoped user snapshots currently loaded.
+
+        Returns:
+            int: The number of guild-scoped snapshots.
+        """
+
+        return sum(len(guild_users) for guild_users in self.user_role_history.values())
+
+    def get_legacy_snapshot_count(self) -> int:
+        """
+        Count legacy snapshots that were saved without guild IDs.
+
+        Returns:
+            int: The number of legacy snapshots.
+        """
+
+        return len(self.legacy_user_role_history)
+
     def save_state(self):
         """
         Save the current role history to disk.
@@ -83,10 +188,19 @@ class RoleHistoryManager:
         with open(self.file_name, "w", encoding="utf-8") as file:
             json.dump(
                 {
-                    "users": {
+                    "guilds": {
+                        guild_id: {
+                            "users": {
+                                user_id: user_record
+                                for user_id, user_record in guild_users.items()
+                            }
+                        }
+                        for guild_id, guild_users in self.user_role_history.items()
+                    },
+                    "legacy_users": {
                         user_id: user_record
-                        for user_id, user_record in self.user_role_history.items()
-                    }
+                        for user_id, user_record in self.legacy_user_role_history.items()
+                    },
                 },
                 file,
                 indent=4,
@@ -99,6 +213,7 @@ class RoleHistoryManager:
 
         if not os.path.exists(self.file_name):
             self.user_role_history = {}
+            self.legacy_user_role_history = {}
             return
 
         with open(self.file_name, "r", encoding="utf-8") as file:
@@ -106,44 +221,60 @@ class RoleHistoryManager:
 
         if not file_content:
             self.user_role_history = {}
+            self.legacy_user_role_history = {}
             return
 
         data = json.loads(file_content)
-        raw_users = data.get("users", data) if isinstance(data, dict) else {}
+        if not isinstance(data, dict):
+            self.user_role_history = {}
+            self.legacy_user_role_history = {}
+            return
 
-        normalized_users = {}
-        for user_id, user_record in raw_users.items():
-            if not isinstance(user_record, dict):
-                continue
+        normalized_guilds: dict[int, dict[int, dict]] = {}
+        raw_guilds = data.get("guilds")
 
-            normalized_roles = {}
-            for role_id, role_record in (user_record.get("roles") or {}).items():
-                if not isinstance(role_record, dict):
+        if isinstance(raw_guilds, dict):
+            for guild_id, guild_record in raw_guilds.items():
+                if not isinstance(guild_record, dict):
                     continue
 
-                normalized_role = self._normalize_role_record(role_record)
-                normalized_roles[str(normalized_role["role_id"] or role_id)] = normalized_role
+                normalized_guild_id = int(guild_id)
+                raw_users = guild_record.get("users", guild_record)
+                if not isinstance(raw_users, dict):
+                    continue
 
-            normalized_users[int(user_id)] = {
-                "user_id": int(user_record.get("user_id", user_id)),
-                "roles": normalized_roles,
-                "updated_at": user_record.get("updated_at", self._timestamp()),
-            }
+                normalized_guilds[normalized_guild_id] = self._normalize_guild_users(
+                    normalized_guild_id,
+                    raw_users,
+                )
 
-        self.user_role_history = normalized_users
+            raw_legacy_users = data.get("legacy_users", {})
+            if isinstance(raw_legacy_users, dict):
+                self.legacy_user_role_history = self._normalize_legacy_users(raw_legacy_users)
+            else:
+                self.legacy_user_role_history = {}
+        else:
+            raw_legacy_users = data.get("users", data)
+            if isinstance(raw_legacy_users, dict):
+                self.legacy_user_role_history = self._normalize_legacy_users(raw_legacy_users)
+            else:
+                self.legacy_user_role_history = {}
 
-    def get_user_history(self, user_id: int) -> Optional[dict]:
+        self.user_role_history = normalized_guilds
+
+    def get_user_history(self, guild_id: int, user_id: int) -> Optional[dict]:
         """
-        Get stored role history for a user.
+        Get stored role history for a user in one guild.
 
         Args:
+            guild_id (int): The Discord guild ID.
             user_id (int): The Discord user ID.
 
         Returns:
             Optional[dict]: The stored user record if one exists.
         """
 
-        return self.user_role_history.get(user_id)
+        return self.user_role_history.get(guild_id, {}).get(user_id)
 
     def snapshot_member_roles(
         self,
@@ -162,7 +293,12 @@ class RoleHistoryManager:
             dict: The updated user record.
         """
 
-        user_record = self.user_role_history.get(member.id) or self._build_empty_user_record(member.id)
+        guild_id = member.guild.id
+        guild_users = self.user_role_history.get(guild_id) or {}
+        user_record = guild_users.get(member.id) or self._build_empty_user_record(
+            guild_id,
+            member.id,
+        )
         snapshot_time = self._timestamp()
         tracked_roles = {}
 
@@ -188,7 +324,8 @@ class RoleHistoryManager:
 
         user_record["roles"] = tracked_roles
         user_record["updated_at"] = snapshot_time
-        self.user_role_history[member.id] = user_record
+        guild_users[member.id] = user_record
+        self.user_role_history[guild_id] = guild_users
         self.save_state()
 
         return user_record
@@ -274,7 +411,7 @@ class RoleHistoryManager:
                 The highest rank role, additional roles, and skipped-role messages.
         """
 
-        user_record = self.get_user_history(member.id)
+        user_record = self.get_user_history(member.guild.id, member.id)
         if user_record is None:
             return None, [], []
 


### PR DESCRIPTION
Restores the roles a member had when they left on rejoin. Saves member role snapshots on interaction with the bot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes role assignment behavior and enables member intents; incorrect config/categorying or permission/hierarchy edge cases could lead to missing or unintended role restores.
> 
> **Overview**
> Adds persistent member role snapshotting and rejoin restoration.
> 
> Introduces `RoleHistoryManager` (backed by `role_history.json`) to record a member’s configured *tracked* roles during bot interactions and after approved role grants, then restores the highest "rank" role plus any "additional" roles when the member rejoins (with safety checks around permissions, managed roles, and role hierarchy). It also hardens guild/member resolution (`get_requests_guild`, `discord.NotFound` handling) and enables the Members intent to support `on_member_join`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d74b80148fff248425daf5f40ddb04670cb66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->